### PR TITLE
Bug fix when I tried to M-x cmd-to-echo RET sh RET -c 'echo ok' RET

### DIFF
--- a/cmd-to-echo.el
+++ b/cmd-to-echo.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Tijs Mallaerts <tijs.mallaerts@gmail.com>
 
-;; Package-Requires: ((emacs "24.4") (s "1.11.0"))
+;; Package-Requires: ((emacs "24.4") (s "1.11.0") (shell-split-string "20150203.1336"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -31,6 +31,7 @@
 (require 'comint)
 (require 's)
 (require 'ansi-color)
+(require 'shell-split-string)
 
 (defvar cmd-to-echo--process-names '()
   "List of process names started with cmd-to-echo.")
@@ -86,7 +87,7 @@ The output of the command will be shown in the echo area."
     (add-to-list 'cmd-to-echo--process-names proc-name)
     (apply 'make-comint (concat command options)
            command nil (unless (string= "" options)
-                         (split-string options " ")))
+                         (shell-split-string options)))
     (let ((proc (get-process proc-name)))
       (set-process-filter proc 'cmd-to-echo--proc-filter))))
 

--- a/cmd-to-echo.el
+++ b/cmd-to-echo.el
@@ -83,11 +83,11 @@ The output of the command will be shown in the echo area."
   (interactive
    (list (read-shell-command "Command to run: ")
          (read-string "Options: ")))
-  (let ((proc-name (concat command options)))
+  (let ((proc-name (concat command " " options)))
     (add-to-list 'cmd-to-echo--process-names proc-name)
-    (apply 'make-comint (concat command options)
-           command nil (unless (string= "" options)
-                         (shell-split-string options)))
+    (apply 'make-comint proc-name command nil
+           (unless (string= "" options)
+             (shell-split-string options)))
     (let ((proc (get-process proc-name)))
       (set-process-filter proc 'cmd-to-echo--proc-filter))))
 


### PR DESCRIPTION
`cmd-to-echo' should handle quoted arguments.